### PR TITLE
Move serialization code out of macro

### DIFF
--- a/bevy_simple_prefs/src/lib.rs
+++ b/bevy_simple_prefs/src/lib.rs
@@ -18,11 +18,13 @@ use bevy::{
     },
     log::warn,
     reflect::{
-        serde::TypedReflectDeserializer, GetTypeRegistration, Reflect, TypePath, TypeRegistry,
+        serde::{TypedReflectDeserializer, TypedReflectSerializer},
+        GetTypeRegistration, Reflect, TypePath, TypeRegistry,
     },
     tasks::{block_on, futures_lite::future, Task},
 };
 pub use bevy_simple_prefs_derive::*;
+use ron::ser::{to_string_pretty, PrettyConfig};
 use serde::de::DeserializeSeed;
 
 /// A trait to be implemented by `bevy_simple_prefs_derive`.
@@ -220,4 +222,14 @@ pub fn deserialize<T: Reflect + GetTypeRegistration + Default>(
     let mut val = T::default();
     val.apply(&*dynamic_struct);
     Ok(val)
+}
+
+/// Serialize preferences
+pub fn serialize<T: Reflect + GetTypeRegistration>(to_save: &T) -> Result<String, ron::Error> {
+    let mut registry = TypeRegistry::new();
+    registry.register::<T>();
+
+    let config = PrettyConfig::default();
+    let reflect_serializer = TypedReflectSerializer::new(to_save, &registry);
+    to_string_pretty(&reflect_serializer, config)
 }

--- a/bevy_simple_prefs_derive/src/lib.rs
+++ b/bevy_simple_prefs_derive/src/lib.rs
@@ -86,12 +86,7 @@ pub fn prefs_derive(input: TokenStream) -> TokenStream {
                             .spawn(async move {
                                 ::bevy::log::debug!("bevy_simple_prefs saving");
 
-                                let mut registry = ::bevy::reflect::TypeRegistry::new();
-                                registry.register::<#name>();
-
-                                let config = ::ron::ser::PrettyConfig::default();
-                                let reflect_serializer = ::bevy::reflect::serde::TypedReflectSerializer::new(&to_save, &registry);
-                                let Ok(serialized_value) = ::ron::ser::to_string_pretty(&reflect_serializer, config) else {
+                                let Ok(serialized_value) = ::bevy_simple_prefs::serialize(&to_save) else {
                                     bevy::log::error!("Failed to serialize prefs.");
                                     return;
                                 };


### PR DESCRIPTION
Some cleanup, with the side effect of no longer requiring users to depend on `ron`.

Fixes #3 