### PR TITLE
Upgrade to Bevy 0.16

### DIFF
--- a/bevy_simple_prefs/Cargo.toml
+++ b/bevy_simple_prefs/Cargo.toml
@@ -14,13 +14,17 @@ exclude = [".github"]
 
 [dependencies]
 bevy_simple_prefs_derive = { path = "../bevy_simple_prefs_derive", version = "0.4" }
-bevy = { version = "0.15", default-features = false }
 web-sys = { version = "0.3", features = ["Window", "Storage"] }
 serde = "1.0"
 ron = "0.8"
 
-[dev-dependencies]
-bevy = { version = "0.15" }
+[dependencies.bevy]
+version = "0.16.0-rc.0"
+default-features = false
+
+[dev-dependencies.bevy]
+version = "0.16.0-rc.0"
+default-features = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 home = "0.5.9"

--- a/bevy_simple_prefs/examples/prefs.rs
+++ b/bevy_simple_prefs/examples/prefs.rs
@@ -175,7 +175,7 @@ fn setup(mut commands: Commands) {
         });
 }
 
-fn build_header(parent: &mut ChildBuilder, text: String) {
+fn build_header(parent: &mut ChildSpawnerCommands, text: String) {
     parent.spawn((
         Text::new(text),
         TextFont {
@@ -186,7 +186,7 @@ fn build_header(parent: &mut ChildBuilder, text: String) {
     ));
 }
 
-fn build_row<'a>(parent: &'a mut ChildBuilder) -> EntityCommands<'a> {
+fn build_row<'a>(parent: &'a mut ChildSpawnerCommands) -> EntityCommands<'a> {
     parent.spawn(Node {
         align_items: AlignItems::Center,
         justify_content: JustifyContent::Center,
@@ -195,7 +195,7 @@ fn build_row<'a>(parent: &'a mut ChildBuilder) -> EntityCommands<'a> {
     })
 }
 
-fn build_label<M: Component>(parent: &mut ChildBuilder, text: String, marker: M) {
+fn build_label<M: Component>(parent: &mut ChildSpawnerCommands, text: String, marker: M) {
     parent
         .spawn((
             Node {
@@ -222,7 +222,7 @@ fn build_label<M: Component>(parent: &mut ChildBuilder, text: String, marker: M)
         });
 }
 
-fn build_button<M: Component>(parent: &mut ChildBuilder, text: String, marker: M) {
+fn build_button<M: Component>(parent: &mut ChildSpawnerCommands, text: String, marker: M) {
     parent
         .spawn((
             Button,

--- a/bevy_simple_prefs/src/lib.rs
+++ b/bevy_simple_prefs/src/lib.rs
@@ -12,11 +12,11 @@ use bevy::{
     app::{App, Plugin, Startup, Update},
     ecs::{
         component::Component,
-        schedule::IntoSystemConfigs,
-        system::{Commands, Query, Resource},
+        system::{Commands, Query},
         world::{CommandQueue, World},
     },
     log::warn,
+    prelude::{IntoScheduleConfigs, Resource},
     reflect::{
         serde::{TypedReflectDeserializer, TypedReflectSerializer},
         GetTypeRegistration, Reflect, TypePath, TypeRegistry,

--- a/bevy_simple_prefs_derive/Cargo.toml
+++ b/bevy_simple_prefs_derive/Cargo.toml
@@ -13,9 +13,13 @@ readme = "README.md"
 exclude = [".github"]
 
 [dependencies]
-bevy = { version = "0.15", default-features = false }
 quote = "1.0"
 syn = "2.0"
+
+[dependencies.bevy]
+version = "0.16.0-rc.0"
+features = ["bevy_log"]
+default-features = false
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
There probably won't be a crates.io release until Bevy 0.16.0 is properly released, but you can use this git branch in the mean time.

```toml
[dependencies.bevy_simple_prefs ]
git = "https://github.com/rparrett/bevy_simple_prefs .git"
branch = "bevy-0.16"