### PR TITLE
Add separate setting for `localStorage` key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,10 @@ jobs:
         run: cargo check
       - name: examples
         run: cargo check --examples
+      - name: check (wasm)
+        run: cargo check --target=wasm32-unknown-unknown
+      - name: examples
+        run: cargo check --examples --target=wasm32-unknown-unknown
       - name: fmt
         run: cargo fmt --all -- --check
       - name: clippy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         run: cargo check --examples
       - name: check (wasm)
         run: cargo check --target=wasm32-unknown-unknown
-      - name: examples
+      - name: examples (wasm)
         run: cargo check --examples --target=wasm32-unknown-unknown
       - name: fmt
         run: cargo fmt --all -- --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          - targets: "wasm32-unknown-unknown"
       - name: Install alsa and udev
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
       - name: check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
         with:
-          - targets: wasm32-unknown-unknown
+          targets: wasm32-unknown-unknown
       - name: Install alsa and udev
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
       - name: check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
         with:
-          - targets: "wasm32-unknown-unknown"
+          - targets: wasm32-unknown-unknown
       - name: Install alsa and udev
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
       - name: check

--- a/bevy_simple_prefs/Cargo.toml
+++ b/bevy_simple_prefs/Cargo.toml
@@ -23,12 +23,15 @@ version = "0.16.0"
 default-features = false
 features = ["bevy_log"]
 
+[dev-dependencies]
+anyhow = "1"
+
 [dev-dependencies.bevy]
 version = "0.16.0"
 default-features = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-home = "0.5.9"
+dirs = "6.0.0"
 
 [lints.rust]
 missing_docs = "warn"

--- a/bevy_simple_prefs/examples/home_dir.rs
+++ b/bevy_simple_prefs/examples/home_dir.rs
@@ -42,10 +42,8 @@ fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
-fn print(mut launches: ResMut<Launches>) {
+fn print(launches: Res<Launches>) {
     if launches.is_changed() && !launches.is_added() {
         info!("Launches: {}", launches.0);
-
-        launches.0 += 1;
     }
 }

--- a/bevy_simple_prefs/examples/home_dir.rs
+++ b/bevy_simple_prefs/examples/home_dir.rs
@@ -3,6 +3,9 @@
 use bevy::{log::LogPlugin, prelude::*};
 use bevy_simple_prefs::{Prefs, PrefsPlugin};
 
+#[cfg(not(target_arch = "wasm32"))]
+use anyhow::Context;
+
 #[derive(Resource, Reflect, Default, Clone)]
 struct Launches(u32);
 
@@ -11,27 +14,38 @@ struct ExamplePrefs {
     launches: Launches,
 }
 
-fn main() {
+fn main() -> anyhow::Result<()> {
     App::new()
         .add_plugins((
             DefaultPlugins.set(LogPlugin {
-                filter: "home_dir=debug,bevy_simple_prefs=debug".into(),
+                filter: "dirs=debug,bevy_simple_prefs=debug".into(),
                 ..default()
             }),
             PrefsPlugin::<ExamplePrefs> {
-                // This value won't be used in WASM builds
-                path: home::home_dir().unwrap_or_default(),
-                // Setting this is optional. `(your_package_name)_prefs.ron` will be used by default.
-                filename: "custom_filename.ron".to_string(),
+                // This example uses the `dirs` crate to locate the user's "local config
+                // directory", e.g. `C:\Users\Alice\AppData\Local` on Windows, or
+                // `/usr/home/alice/.config` on Linux.
+                #[cfg(not(target_arch = "wasm32"))]
+                path: {
+                    let dir = dirs::config_local_dir()
+                        .context("Determining local config directory")?
+                        .join("home_dir");
+                    std::fs::create_dir_all(&dir).context("Creating prefs directory")?;
+                    dir.join("prefs.ron")
+                },
                 ..default()
             },
         ))
         .add_systems(Update, print)
         .run();
+
+    Ok(())
 }
 
-fn print(launches: ResMut<Launches>) {
+fn print(mut launches: ResMut<Launches>) {
     if launches.is_changed() && !launches.is_added() {
         info!("Launches: {}", launches.0);
+
+        launches.0 += 1;
     }
 }

--- a/bevy_simple_prefs/src/lib.rs
+++ b/bevy_simple_prefs/src/lib.rs
@@ -83,7 +83,7 @@ impl<T: Reflect + TypePath> Default for PrefsPlugin<T> {
             // For Wasm, we want to provide a unique name for a project by default
             // to avoid collisions when doing local development or deploying multiple
             // apps to the same web server.
-            local_storage_key: format!("{}::{}.ron", package_name, T::short_type_path()),
+            local_storage_key: format!("{package_name}::{}.ron", T::short_type_path()),
             _phantom: Default::default(),
         }
     }

--- a/bevy_simple_prefs/src/lib.rs
+++ b/bevy_simple_prefs/src/lib.rs
@@ -193,12 +193,9 @@ pub fn save_str(local_storage_key: &str, data: &str) {
         }
     };
 
-    let storage = match window.local_storage() {
-        Ok(Some(s)) => s,
-        _ => {
-            warn!("Failed to store save file: no storage.");
-            return;
-        }
+    let Ok(Some(storage)) = window.local_storage() else {
+        warn!("Failed to store save file: no storage.");
+        return;
     };
 
     if let Err(e) = storage.set_item(local_storage_key, data) {

--- a/bevy_simple_prefs/src/lib.rs
+++ b/bevy_simple_prefs/src/lib.rs
@@ -55,7 +55,7 @@ pub trait Prefs {
 /// App::new().add_plugins(PrefsPlugin::<ExamplePrefs>::default());
 /// ```
 pub struct PrefsPlugin<T: Reflect + TypePath> {
-    /// Path to the file where the preferences file will be stored.
+    /// Path to the file where the preferences will be stored.
     ///
     /// This value is not used in Wasm builds.
     ///

--- a/bevy_simple_prefs/src/lib.rs
+++ b/bevy_simple_prefs/src/lib.rs
@@ -68,7 +68,7 @@ pub struct PrefsPlugin<T: Reflect + TypePath> {
     /// apps on the same web server. On itch.io, for example, many other games
     /// will be using the same storage area.
     ///
-    /// Defaults to `(crate name of T)::(name of T).ron`.
+    /// Defaults to `(crate name of T)::(type name of T).ron`.
     pub local_storage_key: String,
     /// PhantomData
     pub _phantom: PhantomData<T>,

--- a/bevy_simple_prefs/src/lib.rs
+++ b/bevy_simple_prefs/src/lib.rs
@@ -185,12 +185,9 @@ pub fn save_str(path: &std::path::Path, data: &str) {
 /// Persists preferences.
 #[cfg(target_arch = "wasm32")]
 pub fn save_str(local_storage_key: &str, data: &str) {
-    let window = match web_sys::window() {
-        Some(w) => w,
-        None => {
-            warn!("Failed to store save file: no window.");
-            return;
-        }
+    let Some(window) = web_sys::window() else {
+        warn!("Failed to store save file: no window.");
+        return;
     };
 
     let Ok(Some(storage)) = window.local_storage() else {


### PR DESCRIPTION
It was previously not possible to do proper namespacing for Wasm when providing a generic `filename` and a project-specific `path`.

This PR also

- Chooses a slightly better default key for `localStorage`, making it less likely for users utilizing multiple `PrefsPlugins` to experience a collision.
- Improves related docs
- A bit of drive-by tidying
- Adds a couple CI checks for the wasm target