### PR TITLE
Unify loading behavior on Wasm and native

### DIFF
--- a/bevy_simple_prefs_derive/src/lib.rs
+++ b/bevy_simple_prefs_derive/src/lib.rs
@@ -121,7 +121,7 @@ pub fn prefs_derive(input: TokenStream) -> TokenStream {
                                 #[cfg(not(target_arch = "wasm32"))]
                                 let maybe_serialized_value = ::bevy_simple_prefs::load_str(&path);
                                 #[cfg(target_arch = "wasm32")]
-                                let Some(serialized_value) = ::bevy_simple_prefs::load_str(&local_storage_key);
+                                let maybe_serialized_value = ::bevy_simple_prefs::load_str(&local_storage_key);
 
                                 let Some(serialized_value) = maybe_serialized_value else {
                                     return #name::default();


### PR DESCRIPTION
Fixes #13 

Since Bevy 0.15, [tasks are usable](https://github.com/bevyengine/bevy/pull/13889) on Wasm, so we don't need a separate code path there.

