### PR TITLE
Fix saving settings modified in same frame they are initially loaded

### DIFF
--- a/bevy_simple_prefs/src/lib.rs
+++ b/bevy_simple_prefs/src/lib.rs
@@ -5,7 +5,7 @@
 use std::{any::TypeId, marker::PhantomData, path::PathBuf};
 
 use bevy::{
-    app::{App, Plugin, PostUpdate, PreUpdate, Startup},
+    app::{App, Plugin, PostUpdate, Startup},
     ecs::{
         component::Component,
         schedule::{IntoScheduleConfigs, SystemSet},

--- a/bevy_simple_prefs/src/lib.rs
+++ b/bevy_simple_prefs/src/lib.rs
@@ -8,6 +8,7 @@ use bevy::{
     app::{App, Plugin, PostUpdate, PreUpdate, Startup},
     ecs::{
         component::Component,
+        schedule::{IntoScheduleConfigs, SystemSet},
         system::{Commands, Query},
         world::{CommandQueue, World},
     },
@@ -121,6 +122,10 @@ impl<T> Default for PrefsStatus<T> {
 #[derive(Component)]
 pub struct LoadPrefsTask(pub Task<CommandQueue>);
 
+/// A system set containing the system that initializes a save task.
+#[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]
+pub struct PrefsSaveSystems;
+
 #[derive(Resource, Default)]
 struct HandleTasksSystemAdded;
 
@@ -140,12 +145,12 @@ impl<T: Prefs + Reflect + TypePath> Plugin for PrefsPlugin<T> {
             .get_resource::<HandleTasksSystemAdded>()
             .is_none()
         {
-            app.add_systems(PreUpdate, handle_tasks);
+            app.add_systems(PostUpdate, handle_tasks.before(PrefsSaveSystems));
             app.init_resource::<HandleTasksSystemAdded>();
         }
 
         // `save` checks load status and needs to run in the same frame after `handle_tasks`.
-        app.add_systems(PostUpdate, <T>::save);
+        app.add_systems(PostUpdate, <T>::save.in_set(PrefsSaveSystems));
         app.add_systems(Startup, <T>::load);
     }
 }


### PR DESCRIPTION
Fixes #22

#21 moved `HandleTasks` to `PreUpdate`, which broke this.

This moves it back, but adds a `SystemSet` so we can apply the ordering constraint. 