### PR TITLE
Upgrade to Bevy 0.17

### DIFF
--- a/bevy_simple_prefs/Cargo.toml
+++ b/bevy_simple_prefs/Cargo.toml
@@ -19,12 +19,12 @@ serde = "1.0"
 ron = "0.8"
 
 [dependencies.bevy]
-version = "0.16.0"
+version = "0.17.0-rc.0"
 default-features = false
 features = ["bevy_log"]
 
 [dev-dependencies.bevy]
-version = "0.16.0"
+version = "0.17.0-rc.0"
 default-features = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]

--- a/bevy_simple_prefs_derive/Cargo.toml
+++ b/bevy_simple_prefs_derive/Cargo.toml
@@ -17,7 +17,7 @@ quote = "1.0"
 syn = "2.0"
 
 [dependencies.bevy]
-version = "0.16.0"
+version = "0.17.0-rc.0"
 features = ["bevy_log"]
 default-features = false
 

--- a/bevy_simple_prefs_derive/Cargo.toml
+++ b/bevy_simple_prefs_derive/Cargo.toml
@@ -16,11 +16,6 @@ exclude = [".github"]
 quote = "1.0"
 syn = "2.0"
 
-[dependencies.bevy]
-version = "0.17.0-rc.0"
-features = ["bevy_log"]
-default-features = false
-
 [lib]
 proc-macro = true
 


### PR DESCRIPTION
There probably won't be a crates.io release until Bevy 0.17.0 is properly released, but you can use this git branch in the mean time.

```toml
[dependencies.bevy_simple_prefs]
git = "https://github.com/rparrett/bevy_simple_prefs.git"
branch = "bevy-0.17"
```
