### PR TITLE
Upgrade to Bevy 0.18

### DIFF
--- a/bevy_simple_prefs/Cargo.toml
+++ b/bevy_simple_prefs/Cargo.toml
@@ -19,12 +19,12 @@ serde = "1.0"
 ron = "0.8"
 
 [dependencies.bevy]
-version = "0.17.0"
+version = "0.18.0"
 default-features = false
 features = ["bevy_log"]
 
 [dev-dependencies.bevy]
-version = "0.17.0"
+version = "0.18.0"
 default-features = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]

--- a/bevy_simple_prefs/examples/prefs.rs
+++ b/bevy_simple_prefs/examples/prefs.rs
@@ -202,9 +202,9 @@ fn label<M: Component>(text: String, text_marker: M) -> impl Bundle {
             height: Val::Px(50.0),
             justify_content: JustifyContent::Center,
             align_items: AlignItems::Center,
+            border_radius: BorderRadius::all(Val::Px(5.)),
             ..default()
         },
-        BorderRadius::all(Val::Px(5.)),
         BackgroundColor(LABEL_BACKGROUND.into()),
         children![(
             Text::new(text),
@@ -226,9 +226,9 @@ fn button(text: String) -> impl Bundle {
             height: Val::Px(50.0),
             justify_content: JustifyContent::Center,
             align_items: AlignItems::Center,
+            border_radius: BorderRadius::all(Val::Px(5.)),
             ..default()
         },
-        BorderRadius::all(Val::Px(5.)),
         BackgroundColor(NORMAL_BUTTON.into()),
         children![(
             Text::new(text),


### PR DESCRIPTION
This was nearly just a version bump.

One small change to examples because `BorderRadius` was moved to `Node` for... reasons, presumably?